### PR TITLE
Add non sudo setup steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ This tool provides a solution to the [git recursive submodules dependency proble
 sudo pip3 install --prefix /usr/local gil
 ```
 
+## Non-sudo setup
+
+```shell
+pip3 install gil
+echo 'PATH="$HOME/.local/bin/:$PATH"' >> ~/.bashrc # or the .bashrc equivalent for your shell, e.g. .zshrc for zsh
+# Restart terminal
+```
+
 # Sample
 Consider we have the following git repository dependency graph:
 


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/chronoxor/gil/issues/4), there are two ways to make the shell find the gil command, one of which might be useful to users who don't have sudo access, or don't want to use sudo.